### PR TITLE
Use device's reported sample rate for ASIO compatibility

### DIFF
--- a/src/audio/engine.rs
+++ b/src/audio/engine.rs
@@ -7,7 +7,7 @@
 
 use crate::audio::analyzer::{AnalysisResult, Analyzer};
 use crate::audio::signal::MlsGenerator;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{Device, Host, SampleRate, Stream, StreamConfig};
 use ringbuf::traits::{Consumer, Observer, Producer, Split};


### PR DESCRIPTION
## Summary
ASIO devices like VBMatrix VASIO need to use the sample rate reported by the device (from the clock master) rather than forcing a specific rate.

## Changes
- Query device's default output/input configs
- Log what the device reports for debugging
- Use device's reported sample rate if available

## Test plan
- [ ] Test with VB-Matrix VASIO-8 on iem.lan

Generated with [Claude Code](https://claude.com/claude-code)