### PR TITLE
Update Cargo.lock for version 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "audiotester"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "approx",


### PR DESCRIPTION
## Summary
- Fix Cargo.lock to match Cargo.toml version 0.1.5
- Fixes `--locked` build failure in release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)