### PR TITLE
feat: wire sample counters from engine to dashboard

### DIFF
--- a/crates/audiotester-core/src/stats/store.rs
+++ b/crates/audiotester-core/src/stats/store.rs
@@ -382,6 +382,16 @@ impl StatsStore {
     pub fn samples_received(&self) -> u64 {
         self.stats.samples_received
     }
+
+    /// Set samples sent counter (cumulative from engine)
+    pub fn set_samples_sent(&mut self, count: u64) {
+        self.stats.samples_sent = count;
+    }
+
+    /// Set samples received counter (cumulative from engine)
+    pub fn set_samples_received(&mut self, count: u64) {
+        self.stats.samples_received = count;
+    }
 }
 
 impl Default for StatsStore {
@@ -450,5 +460,24 @@ mod tests {
 
         // Should be limited to MAX_HISTORY_SIZE
         assert_eq!(store.latency_history().len(), MAX_HISTORY_SIZE);
+    }
+
+    #[test]
+    fn test_set_sample_counters() {
+        let mut store = StatsStore::new();
+
+        // Set counters directly (cumulative from engine)
+        store.set_samples_sent(1000);
+        store.set_samples_received(999);
+
+        assert_eq!(store.samples_sent(), 1000);
+        assert_eq!(store.samples_received(), 999);
+
+        // Overwrite with new cumulative values
+        store.set_samples_sent(2500);
+        store.set_samples_received(2490);
+
+        assert_eq!(store.samples_sent(), 2500);
+        assert_eq!(store.samples_received(), 2490);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -231,6 +231,14 @@ async fn monitoring_loop(engine: EngineHandle, stats: Arc<Mutex<StatsStore>>, st
                     last_device_name = engine_status.device_name;
                 }
             }
+
+            // Update sample counters from engine (cumulative values)
+            if let Ok((sent, received)) = engine.get_sample_counts().await {
+                if let Ok(mut store) = stats.lock() {
+                    store.set_samples_sent(sent as u64);
+                    store.set_samples_received(received as u64);
+                }
+            }
         }
 
         // Try to analyze


### PR DESCRIPTION
## Summary

- Add `GetSampleCounts` command to `EngineHandle` for retrieving cumulative sample counts from the audio engine
- Add `set_samples_sent()` / `set_samples_received()` methods to `StatsStore` for setting cumulative counter values
- Update monitoring loop to fetch sample counts every second and update the stats store

The OUT/IN counters on the dashboard now show continuously incrementing sample counts instead of always displaying zero.

## Test plan

- [ ] Verify dashboard shows incrementing OUT/IN counters when monitoring is active
- [ ] Verify counters reset to zero when monitoring is stopped
- [ ] Verify counters update in real-time via WebSocket
- [ ] All 163 workspace tests pass
- [ ] Deployed to iem.lan for verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)