### PR TITLE
feat: Live button + latency Y-axis fix for timelines

### DIFF
--- a/crates/audiotester-server/src/ui/dashboard.rs
+++ b/crates/audiotester-server/src/ui/dashboard.rs
@@ -91,6 +91,7 @@ fn DashboardPage() -> impl IntoView {
                                     <button class="zoom-btn" data-range="7d">"7d"</button>
                                     <button class="zoom-btn" data-range="14d">"14d"</button>
                                 </div>
+                                <button class="zoom-btn live active" id="loss-live-btn">"Live"</button>
                             </div>
                             <div id="loss-timeline" class="chart" data-testid="loss-timeline"></div>
                         </div>
@@ -106,6 +107,7 @@ fn DashboardPage() -> impl IntoView {
                                     <button class="zoom-btn" data-range="7d">"7d"</button>
                                     <button class="zoom-btn" data-range="14d">"14d"</button>
                                 </div>
+                                <button class="zoom-btn live active" id="latency-live-btn">"Live"</button>
                             </div>
                             <div id="latency-chart" class="chart" data-testid="latency-timeline"></div>
                         </div>

--- a/crates/audiotester-server/src/ui/scripts/dashboard.js
+++ b/crates/audiotester-server/src/ui/scripts/dashboard.js
@@ -130,7 +130,6 @@
   var lossRefreshTimer = null;
   var lastTotalLost = 0;
   var lossLiveMode = true;
-  var lossUpdating = false;
 
   function initLossTimeline() {
     var container = document.getElementById("loss-timeline");
@@ -233,9 +232,23 @@
       });
     }).observe(container);
 
-    // Detect manual panning to disable live mode
-    lossChart.timeScale().subscribeVisibleLogicalRangeChange(function () {
-      if (!lossUpdating && lossLiveMode) {
+    // Detect user drag/scroll on chart to disable live mode
+    container.addEventListener("mousedown", function () {
+      if (lossLiveMode) {
+        lossLiveMode = false;
+        var btn = document.getElementById("loss-live-btn");
+        if (btn) btn.classList.remove("active");
+      }
+    });
+    container.addEventListener("wheel", function () {
+      if (lossLiveMode) {
+        lossLiveMode = false;
+        var btn = document.getElementById("loss-live-btn");
+        if (btn) btn.classList.remove("active");
+      }
+    });
+    container.addEventListener("touchstart", function () {
+      if (lossLiveMode) {
         lossLiveMode = false;
         var btn = document.getElementById("loss-live-btn");
         if (btn) btn.classList.remove("active");
@@ -317,14 +330,10 @@
           chartData.push({ time: nowLocal, value: 0, color: "transparent" });
         }
 
-        lossUpdating = true;
         lossHistogram.setData(chartData);
         if (lossLiveMode) {
           lossChart.timeScale().scrollToRealTime();
         }
-        setTimeout(function () {
-          lossUpdating = false;
-        }, 0);
 
         // Add "Now" marker at the current time position
         var markerTime =
@@ -362,7 +371,6 @@
   var latencyTimelineRange = "1h";
   var latencyRefreshTimer = null;
   var latencyLiveMode = true;
-  var latencyUpdating = false;
 
   function initLatencyTimeline() {
     var container = document.getElementById("latency-chart");
@@ -461,9 +469,23 @@
       });
     }).observe(container);
 
-    // Detect manual panning to disable live mode
-    latencyChart.timeScale().subscribeVisibleLogicalRangeChange(function () {
-      if (!latencyUpdating && latencyLiveMode) {
+    // Detect user drag/scroll on chart to disable live mode
+    container.addEventListener("mousedown", function () {
+      if (latencyLiveMode) {
+        latencyLiveMode = false;
+        var btn = document.getElementById("latency-live-btn");
+        if (btn) btn.classList.remove("active");
+      }
+    });
+    container.addEventListener("wheel", function () {
+      if (latencyLiveMode) {
+        latencyLiveMode = false;
+        var btn = document.getElementById("latency-live-btn");
+        if (btn) btn.classList.remove("active");
+      }
+    });
+    container.addEventListener("touchstart", function () {
+      if (latencyLiveMode) {
         latencyLiveMode = false;
         var btn = document.getElementById("latency-live-btn");
         if (btn) btn.classList.remove("active");
@@ -531,14 +553,10 @@
             };
           });
 
-        latencyUpdating = true;
         latencyLine.setData(chartData);
         if (latencyLiveMode) {
           latencyChart.timeScale().scrollToRealTime();
         }
-        setTimeout(function () {
-          latencyUpdating = false;
-        }, 0);
 
         // Add "Now" marker on the last data point
         if (chartData.length > 0) {

--- a/crates/audiotester-server/src/ui/scripts/dashboard.js
+++ b/crates/audiotester-server/src/ui/scripts/dashboard.js
@@ -319,10 +319,12 @@
 
         lossUpdating = true;
         lossHistogram.setData(chartData);
-        lossUpdating = false;
         if (lossLiveMode) {
           lossChart.timeScale().scrollToRealTime();
         }
+        setTimeout(function () {
+          lossUpdating = false;
+        }, 0);
 
         // Add "Now" marker at the current time position
         var markerTime =
@@ -532,10 +534,12 @@
 
         latencyUpdating = true;
         latencyLine.setData(chartData);
-        latencyUpdating = false;
         if (latencyLiveMode) {
           latencyChart.timeScale().scrollToRealTime();
         }
+        setTimeout(function () {
+          latencyUpdating = false;
+        }, 0);
 
         // Add "Now" marker on the last data point
         if (chartData.length > 0) {

--- a/crates/audiotester-server/src/ui/scripts/dashboard.js
+++ b/crates/audiotester-server/src/ui/scripts/dashboard.js
@@ -129,6 +129,8 @@
   var lossTimelineRange = "1h";
   var lossRefreshTimer = null;
   var lastTotalLost = 0;
+  var lossLiveMode = true;
+  var lossUpdating = false;
 
   function initLossTimeline() {
     var container = document.getElementById("loss-timeline");
@@ -231,6 +233,27 @@
       });
     }).observe(container);
 
+    // Detect manual panning to disable live mode
+    lossChart.timeScale().subscribeVisibleLogicalRangeChange(function () {
+      if (!lossUpdating && lossLiveMode) {
+        lossLiveMode = false;
+        var btn = document.getElementById("loss-live-btn");
+        if (btn) btn.classList.remove("active");
+      }
+    });
+
+    // Live button handler
+    var lossLiveBtn = document.getElementById("loss-live-btn");
+    if (lossLiveBtn) {
+      lossLiveBtn.addEventListener("click", function () {
+        lossLiveMode = true;
+        lossLiveBtn.classList.add("active");
+        if (lossChart) {
+          lossChart.timeScale().scrollToRealTime();
+        }
+      });
+    }
+
     // Setup zoom button handlers
     var zoomControls = document.getElementById("loss-zoom-controls");
     if (zoomControls) {
@@ -294,7 +317,12 @@
           chartData.push({ time: nowLocal, value: 0, color: "transparent" });
         }
 
+        lossUpdating = true;
         lossHistogram.setData(chartData);
+        lossUpdating = false;
+        if (lossLiveMode) {
+          lossChart.timeScale().scrollToRealTime();
+        }
 
         // Add "Now" marker at the current time position
         var markerTime =
@@ -331,6 +359,8 @@
   var latencyMarkers = null;
   var latencyTimelineRange = "1h";
   var latencyRefreshTimer = null;
+  var latencyLiveMode = true;
+  var latencyUpdating = false;
 
   function initLatencyTimeline() {
     var container = document.getElementById("latency-chart");
@@ -369,6 +399,12 @@
           return price.toFixed(1) + " ms";
         },
         minMove: 0.1,
+      },
+      autoscaleInfoProvider: function () {
+        return {
+          priceRange: { minValue: null, maxValue: null },
+          margins: { above: 0.1, below: 0.1 },
+        };
       },
     });
 
@@ -424,6 +460,27 @@
       });
     }).observe(container);
 
+    // Detect manual panning to disable live mode
+    latencyChart.timeScale().subscribeVisibleLogicalRangeChange(function () {
+      if (!latencyUpdating && latencyLiveMode) {
+        latencyLiveMode = false;
+        var btn = document.getElementById("latency-live-btn");
+        if (btn) btn.classList.remove("active");
+      }
+    });
+
+    // Live button handler
+    var latencyLiveBtn = document.getElementById("latency-live-btn");
+    if (latencyLiveBtn) {
+      latencyLiveBtn.addEventListener("click", function () {
+        latencyLiveMode = true;
+        latencyLiveBtn.classList.add("active");
+        if (latencyChart) {
+          latencyChart.timeScale().scrollToRealTime();
+        }
+      });
+    }
+
     // Setup zoom button handlers
     var zoomControls = document.getElementById("latency-zoom-controls");
     if (zoomControls) {
@@ -473,7 +530,12 @@
             };
           });
 
+        latencyUpdating = true;
         latencyLine.setData(chartData);
+        latencyUpdating = false;
+        if (latencyLiveMode) {
+          latencyChart.timeScale().scrollToRealTime();
+        }
 
         // Add "Now" marker on the last data point
         if (chartData.length > 0) {

--- a/crates/audiotester-server/src/ui/scripts/dashboard.js
+++ b/crates/audiotester-server/src/ui/scripts/dashboard.js
@@ -402,12 +402,11 @@
         },
         minMove: 0.1,
       },
-      autoscaleInfoProvider: function () {
-        return {
-          priceRange: { minValue: null, maxValue: null },
-          margins: { above: 0.1, below: 0.1 },
-        };
-      },
+    });
+
+    // Tight Y-axis margins to avoid zero-start visual artifact
+    latencyLine.priceScale().applyOptions({
+      scaleMargins: { top: 0.1, bottom: 0.1 },
     });
 
     // Tooltip overlay for exact latency values on hover

--- a/crates/audiotester-server/src/ui/styles/dashboard.css
+++ b/crates/audiotester-server/src/ui/styles/dashboard.css
@@ -282,6 +282,10 @@ main {
   border-color: rgba(0, 212, 255, 0.3);
 }
 
+.zoom-btn.live {
+  margin-left: 0.5rem;
+}
+
 .chart {
   width: 100%;
   flex: 1;

--- a/e2e/latency-timeline.spec.ts
+++ b/e2e/latency-timeline.spec.ts
@@ -125,4 +125,34 @@ test.describe("Latency Timeline UI", () => {
     await expect(btn14d).toHaveClass(/active/);
     await expect(btn1h).not.toHaveClass(/active/);
   });
+
+  test("Live button is visible on latency timeline", async ({ page }) => {
+    await page.goto("/");
+    const liveBtn = page.locator("#latency-live-btn");
+    await expect(liveBtn).toBeVisible();
+    await expect(liveBtn).toHaveText("Live");
+  });
+
+  test("Live button is active by default on latency timeline", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const liveBtn = page.locator("#latency-live-btn");
+    await expect(liveBtn).toHaveClass(/active/);
+  });
+
+  test("clicking Live button adds active class on latency timeline", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const liveBtn = page.locator("#latency-live-btn");
+
+    // Remove active class first by simulating what pan detection would do
+    await liveBtn.evaluate((el) => el.classList.remove("active"));
+    await expect(liveBtn).not.toHaveClass(/active/);
+
+    // Click should re-activate
+    await liveBtn.click();
+    await expect(liveBtn).toHaveClass(/active/);
+  });
 });

--- a/e2e/loss-timeline.spec.ts
+++ b/e2e/loss-timeline.spec.ts
@@ -153,4 +153,34 @@ test.describe("Loss Timeline UI", () => {
     const header = page.locator(".chart-header");
     await expect(header.first()).toBeVisible();
   });
+
+  test("Live button is visible on loss timeline", async ({ page }) => {
+    await page.goto("/");
+    const liveBtn = page.locator("#loss-live-btn");
+    await expect(liveBtn).toBeVisible();
+    await expect(liveBtn).toHaveText("Live");
+  });
+
+  test("Live button is active by default on loss timeline", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const liveBtn = page.locator("#loss-live-btn");
+    await expect(liveBtn).toHaveClass(/active/);
+  });
+
+  test("clicking Live button adds active class on loss timeline", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const liveBtn = page.locator("#loss-live-btn");
+
+    // Remove active class first by simulating what pan detection would do
+    await liveBtn.evaluate((el) => el.classList.remove("active"));
+    await expect(liveBtn).not.toHaveClass(/active/);
+
+    // Click should re-activate
+    await liveBtn.click();
+    await expect(liveBtn).toHaveClass(/active/);
+  });
 });


### PR DESCRIPTION
## Summary

- **Live button** on both loss and latency timelines — defaults to active (cyan), auto-scrolls to latest data on refresh. Clicking the chart (mousedown/wheel/touch) disables live mode; clicking the Live button re-enables it and scrolls to real-time.
- **Latency Y-axis fix** — tight `scaleMargins` (10% top/bottom) prevent the Y-axis from extending to zero when actual measurements are ~50-60ms.
- **6 new E2E tests** — Live button visibility, default active state, and click re-activation for both timelines.

## Test plan

- [x] All 12 CI jobs pass (fmt, clippy, build, test, e2e, playwright, deploy-dev, smoke tests)
- [x] Hardware smoke tests pass on iem.lan with VASIO-8
- [x] Live buttons render with cyan active state after page load
- [x] Live buttons retain active class after JS init + data fetch (verified via `document.getElementById().className`)
- [x] Latency line renders at actual values (~58.7ms), Y-axis does not extend to zero
- [x] Loss timeline histogram renders with "Now" marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)